### PR TITLE
Add ability to write Dockerfile instructions to a stream rather than a physical file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,3 +166,11 @@ myFile.write("../my-image", true, function(err, content) {
 	else doSuccessFunction();
 });
 ```
+
+**writeStream()**
+```javascript
+var fs = require('fs');
+
+myFile.writeStream()
+      .pipe(fs.createWriteStream('Dockerfile'));
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,28 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
 var fs = require("fs");
 var path = require("path");
+var stream = require("stream");
+var StringStream = (function (_super) {
+    __extends(StringStream, _super);
+    function StringStream(buffer) {
+        _super.call(this);
+        this.buffer = null;
+        this.buffer = buffer;
+    }
+    StringStream.prototype._read = function (size) {
+        if (this.buffer !== null) {
+            this.push(this.buffer);
+            this.buffer = null;
+        }
+        this.push(null);
+    };
+    return StringStream;
+})(stream.Readable);
 var Builder = (function () {
     function Builder() {
         this.instructions = [];
@@ -73,6 +96,10 @@ var Builder = (function () {
     Builder.prototype.write = function (location, replaceExisting, callback) {
         var content = buildInstructionsString(this.instructions);
         writeDockerfile(content, location, replaceExisting, callback);
+    };
+    Builder.prototype.writeStream = function () {
+        var content = buildInstructionsString(this.instructions);
+        return new StringStream(content);
     };
     return Builder;
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,27 @@
 import fs = require("fs");
 import path = require("path");
+import stream = require("stream");
+
 export = Builder;
+
+class StringStream extends stream.Readable {
+	buffer: string = null;
+	
+	constructor(buffer : string) {
+		super();
+		
+		this.buffer = buffer;
+	}
+	
+	_read(size: number): void {
+		if (this.buffer !== null) {
+			this.push(this.buffer);
+			this.buffer = null;
+		}
+		
+		this.push(null);
+	}
+}
 
 class Builder implements DockerFileBuilder {
 	constructor() { }
@@ -91,6 +112,12 @@ class Builder implements DockerFileBuilder {
 	write(location: string, replaceExisting: boolean, callback: DockerCallback) {
 		var content = buildInstructionsString(this.instructions);
 		writeDockerfile(content, location, replaceExisting, callback);
+	}
+	
+	writeStream() {
+		var content = buildInstructionsString(this.instructions);
+
+		return new StringStream(content);
 	}
 }
 

--- a/src/typings/node-dockerfile/node-dockerfile.d.ts
+++ b/src/typings/node-dockerfile/node-dockerfile.d.ts
@@ -2,7 +2,7 @@ declare module "node-dockerfile" {
 	export = DockerFileBuilder;
 }
 
-declare class DockerFileBuilder {
+declare class DockerFileBuilder {	
 	from(image: string): DockerFileBuilder;
 	maintainer(maintainer: string): DockerFileBuilder;
 	run(instructions: string|string[]): DockerFileBuilder;
@@ -19,7 +19,8 @@ declare class DockerFileBuilder {
 	onBuild(instructions: string): DockerFileBuilder;
 	comment(comment: string): DockerFileBuilder;
 	newLine(): DockerFileBuilder;
-	write(writeLocation: string, replaceExisting: boolean, callback: DockerCallback): void;	
+	write(writeLocation: string, replaceExisting: boolean, callback: DockerCallback): void;
+	writeStream(): NodeJS.ReadableStream;	
 }
 
 interface DockerCallback {


### PR DESCRIPTION
Adds the method `writeStream()` to the DockerFileBuilder interface that returns a `ReadableStream` that represents the current instructions accumulated by the builder.  The stream can then be piped to any number of places, such as a write-able file stream.  E.g.:

``` javascript
var fs = require('fs');

myFile.writeStream()
      .pipe(fs.createWriteStream('Dockerfile'));
```

The advantage of this new method is that it allows piping the Dockerfile contents elsewhere (e.g. a tar stream) without having to first write it to (and then read it from) a physical disk.

The Builder class implements the `writeStream()` method by creating and returning a `Readable` stream implementation, `StringStream`, that simply returns the current instructions string.
