### PR TITLE
Fixes issue where arguments to the COPY instruction were misformatted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var fs = require("fs");
 var path = require("path");
@@ -45,7 +46,7 @@ var Builder = (function () {
         return this;
     };
     Builder.prototype.copy = function (source, destination) {
-        this.instructions.push(makeInstruction("COPY", source + " = " + destination));
+        this.instructions.push(makeInstruction("COPY", source + " " + destination));
         return this;
     };
     Builder.prototype.entryPoint = function (instructions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ class Builder implements DockerFileBuilder {
     }
 
     copy(source: string, destination: string) {
-        this.instructions.push(makeInstruction("COPY", `${source} = ${destination}`));
+        this.instructions.push(makeInstruction("COPY", `${source} ${destination}`));
         return this;
     }
 


### PR DESCRIPTION
A recent refactoring updated several Docker instructions to use formatted strings rather than string concatenation.  The `COPY` instruction, however, ended up with an extraneous `=` in the formatted string that causes image creation to fail.

Expected: `COPY . /app`
Actual: `COPY . = /app`

This change just removes the `=`.
